### PR TITLE
scripts: modify script to push kube-etcd-signer-server and kube-client-agent images

### DIFF
--- a/scripts/after-success.sh
+++ b/scripts/after-success.sh
@@ -3,4 +3,6 @@
 if [[ $TRAVIS_PULL_REQUEST == "false" ]] && [[ $TRAVIS_BRANCH == "master" ]]; then
     docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD" quay.io;
     make push/kube-aws-approver;
+    make push/kube-etcd-signer-server;
+    make push/kube-client-agent;
 fi


### PR DESCRIPTION
This allows Travis CI to push kube-etcd-signer-server and kube-client-agent images to quay