### PR TITLE
certagent: use kubeconfig to create client for k8s api

### DIFF
--- a/pkg/certagent/agent_test.go
+++ b/pkg/certagent/agent_test.go
@@ -14,11 +14,10 @@ import (
 
 var (
 	cConfig = CSRConfig{
-		DNSNames:      []string{"localhost"},
-		IPAddresses:   []net.IP{net.ParseIP("127.0.0.1")},
-		OrgName:       "system:etcd-peers",
-		CommonName:    "system:etcd-peer:test",
-		SignerAddress: "http://127.0.0.1:6443",
+		DNSNames:    []string{"localhost"},
+		IPAddresses: []net.IP{net.ParseIP("127.0.0.1")},
+		OrgName:     "system:etcd-peers",
+		CommonName:  "system:etcd-peer:test",
 	}
 )
 


### PR DESCRIPTION
Currently the certagent accepts --rootca and --addr, while almost all k8s clients
usually use the kubeconfig file for creating requests to the k8s api.
This also allows the cert agent to create requests with authentication.

/cc @crawford 