### PR TITLE
kube-etcd-signer-server: add sign subcommand to sign CSRs from k8s API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ROOT_DIR:=$(shell git rev-parse --show-toplevel)
 GOFILES:=$(shell find . -name '*.go' | grep -v -E '(./vendor)')
 GOFLAGS=
-IMAGE_REPO=
+IMAGE_REPO=quay.io/coreos
 IMAGE_TAG:=$(shell $(ROOT_DIR)/scripts/git-version.sh)
 
 $( shell mkdir -p bin )
@@ -25,22 +25,22 @@ bin/kube-client-agent: $(GOFILES)
 	@go build $(GOFLAGS) -o $(ROOT_DIR)/bin/kube-client-agent github.com/coreos/kubecsr/cmd/kube-client-agent
 
 image/kube-aws-approver:
-	@docker build -t quay.io/coreos/kube-aws-approver:$(IMAGE_TAG) -f $(ROOT_DIR)/dockerfiles/Dockerfile.kube-aws-approver .
+	@docker build -t $(IMAGE_REPO)/kube-aws-approver:$(IMAGE_TAG) -f $(ROOT_DIR)/dockerfiles/Dockerfile.kube-aws-approver .
 
 push/kube-aws-approver: image/kube-aws-approver
-	@docker push quay.io/coreos/kube-aws-approver:$(IMAGE_TAG)
+	@docker push $(IMAGE_REPO)/kube-aws-approver:$(IMAGE_TAG)
 
 image/kube-etcd-signer-server:
-	@docker build -t quay.io/coreos/kube-etcd-signer-server:$(IMAGE_TAG) -f $(ROOT_DIR)/dockerfiles/Dockerfile.kube-etcd-signer-server .
+	@docker build -t $(IMAGE_REPO)/kube-etcd-signer-server:$(IMAGE_TAG) -f $(ROOT_DIR)/dockerfiles/Dockerfile.kube-etcd-signer-server .
 
 push/kube-etcd-signer-server: image/kube-etcd-signer-server
-	@docker push quay.io/coreos/kube-etcd-signer-server:$(IMAGE_TAG)
+	@docker push $(IMAGE_REPO)/kube-etcd-signer-server:$(IMAGE_TAG)
 
 image/kube-client-agent:
-	@docker build -t quay.io/coreos/kube-client-agent:$(IMAGE_TAG) -f $(ROOT_DIR)/dockerfiles/Dockerfile.kube-client-agent .
+	@docker build -t $(IMAGE_REPO)/kube-client-agent:$(IMAGE_TAG) -f $(ROOT_DIR)/dockerfiles/Dockerfile.kube-client-agent .
 
 push/kube-client-agent: image/kube-client-agent
-	@docker push quay.io/coreos/kube-client-agent:$(IMAGE_TAG)
+	@docker push $(IMAGE_REPO)/kube-client-agent:$(IMAGE_TAG)
 
 test:
 	@go test -v -i $(shell go list ./... | grep -v '/vendor/')

--- a/cmd/kube-etcd-signer-server/main.go
+++ b/cmd/kube-etcd-signer-server/main.go
@@ -1,17 +1,42 @@
 package main
 
 import (
+	"errors"
+
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 )
 
 var (
 	rootCmd = &cobra.Command{
-		Use:   "kube-etcd-signer-server",
-		Short: "Certificate signer server",
-		Long:  "",
+		Use:               "kube-etcd-signer-server",
+		Short:             "Certificate signer server",
+		Long:              "",
+		PersistentPreRunE: validateRootOpts,
+	}
+
+	rootOpts struct {
+		caCrtFile     string
+		caKeyFile     string
+		peerCertDur   string
+		serverCertDur string
 	}
 )
+
+func init() {
+	rootCmd.PersistentFlags().StringVar(&rootOpts.caCrtFile, "cacrt", "", "CA certificate file for signer")
+	rootCmd.PersistentFlags().StringVar(&rootOpts.caKeyFile, "cakey", "", "CA private key file for signer")
+	rootCmd.PersistentFlags().StringVar(&rootOpts.peerCertDur, "peercertdur", "8760h", "Certificate duration for etcd peer certs (defaults to 365 days)")
+	rootCmd.PersistentFlags().StringVar(&rootOpts.serverCertDur, "servercertdur", "8760h", "Certificate duration for etcd server certs (defaults to 365 days)")
+}
+
+// validateRootOpts validates the user flag values given to the signer server
+func validateRootOpts(cmd *cobra.Command, args []string) error {
+	if rootOpts.caCrtFile == "" || rootOpts.caKeyFile == "" {
+		return errors.New("both --cacrt and --cakey are required flags")
+	}
+	return nil
+}
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {

--- a/cmd/kube-etcd-signer-server/serve.go
+++ b/cmd/kube-etcd-signer-server/serve.go
@@ -19,34 +19,24 @@ var (
 	}
 
 	serveOpts struct {
-		caCrtFile     string
-		caKeyFile     string
-		sCrtFile      string
-		sKeyFile      string
-		addr          string
-		peerCertDur   string
-		serverCertDur string
-		csrDir        string
+		sCrtFile string
+		sKeyFile string
+		addr     string
+		csrDir   string
 	}
 )
 
 func init() {
 	rootCmd.AddCommand(serveCmd)
-	serveCmd.PersistentFlags().StringVar(&serveOpts.caCrtFile, "cacrt", "", "CA certificate file for signer")
-	serveCmd.PersistentFlags().StringVar(&serveOpts.caKeyFile, "cakey", "", "CA private key file for signer")
+
 	serveCmd.PersistentFlags().StringVar(&serveOpts.sCrtFile, "servcrt", "", "Server certificate file for signer")
 	serveCmd.PersistentFlags().StringVar(&serveOpts.sKeyFile, "servkey", "", "Server private key file for signer")
 	serveCmd.PersistentFlags().StringVar(&serveOpts.addr, "address", "0.0.0.0:6443", "Address on which the signer listens for requests")
-	serveCmd.PersistentFlags().StringVar(&serveOpts.peerCertDur, "peercertdur", "8760h", "Certificate duration for etcd peer certs (defaults to 365 days)")
-	serveCmd.PersistentFlags().StringVar(&serveOpts.serverCertDur, "servercertdur", "8760h", "Certificate duration for etcd server certs (defaults to 365 days)")
 	serveCmd.PersistentFlags().StringVar(&serveOpts.csrDir, "csrdir", "", "Directory location where signer will save CSRs.")
 }
 
 // validateServeOpts validates the user flag values given to the signer server
 func validateServeOpts(cmd *cobra.Command, args []string) error {
-	if serveOpts.caCrtFile == "" || serveOpts.caKeyFile == "" {
-		return errors.New("both --cacrt and --cakey are required flags")
-	}
 	if serveOpts.sCrtFile == "" || serveOpts.sKeyFile == "" {
 		return errors.New("both --servcrt and --servkey are required flags")
 	}
@@ -58,25 +48,27 @@ func validateServeOpts(cmd *cobra.Command, args []string) error {
 
 // runCmdServe invokes an instance of the signer with the given configuration arguments
 func runCmdServe(cmd *cobra.Command, args []string) error {
-	pCertDur, err := time.ParseDuration(serveOpts.peerCertDur)
+	pCertDur, err := time.ParseDuration(rootOpts.peerCertDur)
 	if err != nil {
 		return fmt.Errorf("error parsing duration for etcd peer cert: %v", err)
 	}
 
-	sCertDur, err := time.ParseDuration(serveOpts.serverCertDur)
+	sCertDur, err := time.ParseDuration(rootOpts.serverCertDur)
 	if err != nil {
 		return fmt.Errorf("error parsing duration for etcd server cert: %v", err)
 	}
 
-	c := signer.Config{
-		CACertFile:             serveOpts.caCrtFile,
-		CAKeyFile:              serveOpts.caKeyFile,
-		ServerCertFile:         serveOpts.sCrtFile,
-		ServerKeyFile:          serveOpts.sKeyFile,
-		ListenAddress:          serveOpts.addr,
-		EtcdPeerCertDuration:   pCertDur,
-		EtcdServerCertDuration: sCertDur,
-		CSRDir:                 serveOpts.csrDir,
+	c := signer.ServerConfig{
+		Config: signer.Config{
+			CACertFile:             rootOpts.caCrtFile,
+			CAKeyFile:              rootOpts.caKeyFile,
+			ServerCertFile:         serveOpts.sCrtFile,
+			ServerKeyFile:          serveOpts.sKeyFile,
+			ListenAddress:          serveOpts.addr,
+			EtcdPeerCertDuration:   pCertDur,
+			EtcdServerCertDuration: sCertDur,
+		},
+		CSRDir: serveOpts.csrDir,
 	}
 
 	if err := signer.StartSignerServer(c); err != nil {

--- a/cmd/kube-etcd-signer-server/sign.go
+++ b/cmd/kube-etcd-signer-server/sign.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	certificatesclient "k8s.io/client-go/kubernetes/typed/certificates/v1beta1"
+	"k8s.io/client-go/tools/clientcmd"
+
+	signer "github.com/coreos/kubecsr/pkg/certsigner"
+)
+
+var (
+	signCmd = &cobra.Command{
+		Use:     "sign CSR_NAME --FLAGS",
+		Short:   "sign certificate signing requests",
+		Long:    "This command runs signs the specified certificate signing request from k8s API",
+		PreRunE: validateSignOpts,
+		RunE:    runCmdSign,
+	}
+
+	signOpts struct {
+		kubeconfig string
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(signCmd)
+
+	signCmd.PersistentFlags().StringVar(&signOpts.kubeconfig, "kubeconfig", "", "Kubeconfig used to communicate with k8s API.")
+}
+
+// validateSignOpts validates the user flag values given to the signer server
+func validateSignOpts(cmd *cobra.Command, args []string) error {
+	if signOpts.kubeconfig == "" {
+		return errors.New("missing required flag: --kubeconfig")
+	}
+
+	if len(args) != 1 {
+		return errors.New("exactly one arg<CSR_NAME> required")
+	}
+	return nil
+}
+
+// runCmdSign invokes an instance of the signer with the given configuration arguments
+func runCmdSign(cmd *cobra.Command, args []string) error {
+	pCertDur, err := time.ParseDuration(rootOpts.peerCertDur)
+	if err != nil {
+		return fmt.Errorf("error parsing duration for etcd peer cert: %v", err)
+	}
+
+	sCertDur, err := time.ParseDuration(rootOpts.serverCertDur)
+	if err != nil {
+		return fmt.Errorf("error parsing duration for etcd server cert: %v", err)
+	}
+
+	c := signer.Config{
+		CACertFile:             rootOpts.caCrtFile,
+		CAKeyFile:              rootOpts.caKeyFile,
+		ServerCertFile:         serveOpts.sCrtFile,
+		ServerKeyFile:          serveOpts.sKeyFile,
+		ListenAddress:          serveOpts.addr,
+		EtcdPeerCertDuration:   pCertDur,
+		EtcdServerCertDuration: sCertDur,
+	}
+
+	s, err := signer.NewSigner(c)
+	if err != nil {
+		return err
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", signOpts.kubeconfig)
+	if err != nil {
+		return err
+	}
+	client, err := certificatesclient.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+
+	return signer.Sign(s, client.CertificateSigningRequests(), args[0])
+}

--- a/pkg/certsigner/server.go
+++ b/pkg/certsigner/server.go
@@ -1,0 +1,161 @@
+package certsigner
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
+
+	"github.com/cloudflare/cfssl/log"
+	"github.com/golang/glog"
+	"github.com/gorilla/mux"
+	capi "k8s.io/api/certificates/v1beta1"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+// CertServer is the object that handles the HTTP requests and responses.
+// It recieves CSR approval requests from the client agent which the `signer`
+// then attempts to sign. If successful, the approved CSR is returned to the
+// agent which contains the signed certificate.
+type CertServer struct {
+	// mux is a request router instance
+	mux *mux.Router
+	// csrDir is the directory location where the signer stores CSRs
+	csrDir string
+	// signer is the object that handles the approval of the CSRs
+	signer *CertSigner
+}
+
+// ServerConfig holds the configuration values required to start a new signer server
+type ServerConfig struct {
+	Config
+	// CSRDir is the directory location where the signer stores CSRs and serves them
+	CSRDir string
+}
+
+// loggingHandler is the HTTP handler that logs information about requests received by the server
+type loggingHandler struct {
+	h http.Handler
+}
+
+func (l *loggingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	log.Info(r.Method, r.URL.Path)
+	l.h.ServeHTTP(w, r)
+}
+
+// NewServer returns a CertServer object that has a CertSigner object
+// as a part of it
+func NewServer(c ServerConfig) (*CertServer, error) {
+	signer, err := NewSigner(c.Config)
+	if err != nil {
+		return nil, fmt.Errorf("error setting up a signer: %v", err)
+	}
+
+	mux := mux.NewRouter()
+	server := &CertServer{
+		mux:    mux,
+		csrDir: c.CSRDir,
+		signer: signer,
+	}
+
+	mux.HandleFunc("/apis/certificates.k8s.io/v1beta1/certificatesigningrequests", server.HandlePostCSR).Methods("POST")
+	mux.HandleFunc("/apis/certificates.k8s.io/v1beta1/certificatesigningrequests/{csrName}", server.HandleGetCSR).Methods("GET")
+
+	return server, nil
+}
+
+func (s *CertServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mux.ServeHTTP(w, r)
+}
+
+// HandlePostCSR takes in a CSR, attempts to approve it and writes the CSR
+// to a file in the `csrDir`.
+// It returns a `http.StatusOK` to the client if the recieved CSR can
+// be sucessfully decoded.
+func (s *CertServer) HandlePostCSR(w http.ResponseWriter, r *http.Request) {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		glog.Errorf("Error reading request body: %v", err)
+		http.Error(w, "Failed to read request body", http.StatusInternalServerError)
+		return
+	}
+
+	obj, _, err := scheme.Codecs.UniversalDeserializer().Decode(body, nil, nil)
+	if err != nil {
+		glog.Errorf("Error decoding request body: %v", err)
+		http.Error(w, "Failed to decode request body", http.StatusInternalServerError)
+		return
+	}
+
+	csr, ok := obj.(*capi.CertificateSigningRequest)
+	if !ok {
+		glog.Errorf("Invalid Certificate Signing Request in request from agent: %v", err)
+		http.Error(w, "Invalid Certificate Signing Request", http.StatusBadRequest)
+		return
+	}
+
+	signedCSR, err := s.signer.Sign(csr)
+	if err != nil {
+		glog.Errorf("Error signing CSR provided in request from agent: %v", err)
+		http.Error(w, "Error signing csr", http.StatusBadRequest)
+		return
+	}
+
+	csrBytes, err := json.Marshal(signedCSR)
+	if err != nil {
+		glog.Errorf("Error marshalling approved CSR: %v", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	// write CSR to disk which will then be served to the agent.
+	csrFile := path.Join(s.csrDir, signedCSR.ObjectMeta.Name)
+	if err := ioutil.WriteFile(csrFile, csrBytes, 0600); err != nil {
+		glog.Errorf("Unable to write to %s: %v", csrFile, err)
+	}
+
+	// Send the signed CSR back to the client agent
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(csrBytes)
+
+	return
+}
+
+// HandleGetCSR retrieves a CSR from a directory location (`csrDir`) and returns it
+// to an agent.
+func (s *CertServer) HandleGetCSR(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	csrName := vars["csrName"]
+
+	if _, err := os.Stat(filepath.Join(s.csrDir, csrName)); os.IsNotExist(err) {
+		// csr file does not exist in `csrDir`
+		http.Error(w, "CSR not found with given CSR name"+csrName, http.StatusNotFound)
+		return
+	}
+
+	data, err := ioutil.ReadFile(filepath.Join(s.csrDir, csrName))
+	if err != nil {
+		http.Error(w, "error reading CSR from file", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+	w.Write(data)
+	return
+}
+
+// StartSignerServer initializes a new signer instance.
+func StartSignerServer(c ServerConfig) error {
+	s, err := NewServer(c)
+	if err != nil {
+		return fmt.Errorf("error setting up signer: %v", err)
+	}
+
+	h := &loggingHandler{s.mux}
+	return http.ListenAndServeTLS(c.ListenAddress, c.ServerCertFile, c.ServerKeyFile, h)
+}


### PR DESCRIPTION
Adds a sign subcommand that can be used by user to sign a CSR from k8s API using
the internal signer.