### PR TITLE
pkg/certsigner/signer: Add "client" usage to server profile

### DIFF
--- a/pkg/certsigner/signer.go
+++ b/pkg/certsigner/signer.go
@@ -164,6 +164,7 @@ func NewSigner(c Config) (*CertSigner, error) {
 				Usage: []string{
 					string(capi.UsageKeyEncipherment),
 					string(capi.UsageDigitalSignature),
+					string(capi.UsageClientAuth),
 					string(capi.UsageServerAuth),
 				},
 				Expiry:       c.EtcdServerCertDuration,


### PR DESCRIPTION
Avoid issues [like][1]:

```
WARNING: 2018/05/29 11:17:10 Failed to dial 127.0.0.1:2379: connection error: desc = "transport: authentication handshake failed: remote error: tls: bad certificate"; please retry.
```

In the discussion there, the issue seems to be that [etcd 3.2 started requiring the client usage for the server cert][2], which is (for some reason) used when connecting to [the gRPC gateway][3] (although I haven't been able to find the etcd code backing that up).

CC @praveenkumar, who saw this issue [here][4].

[1]: https://github.com/etcd-io/etcd/issues/9785#issue-327157868
[2]: https://github.com/etcd-io/etcd/issues/9785#issuecomment-396715692
[3]: https://github.com/etcd-io/etcd/blob/v3.3.10/Documentation/dev-guide/api_grpc_gateway.md
[4]: https://github.com/openshift/installer/issues/167#issuecomment-444426953