### PR TITLE
add new option csrName to specify the csr object's name

### DIFF
--- a/cmd/kube-client-agent/request.go
+++ b/cmd/kube-client-agent/request.go
@@ -26,6 +26,7 @@ var (
 		ipAddresses string
 		assetsDir   string
 		kubeconfig  string
+		csrName     string
 	}
 )
 
@@ -35,6 +36,7 @@ func init() {
 	requestCmd.PersistentFlags().StringVar(&requestOpts.orgName, "orgname", "", "CA private key file for signer")
 	requestCmd.PersistentFlags().StringVar(&requestOpts.dnsNames, "dnsnames", "", "Comma separated DNS names of the node to be provided for the X509 certificate")
 	requestCmd.PersistentFlags().StringVar(&requestOpts.ipAddresses, "ipaddrs", "", "Comma separated IP addresses of the node to be provided for the X509 certificate")
+	requestCmd.PersistentFlags().StringVar(&requestOpts.csrName, "name", "", "Name for the CertificateSigningRequest object, defaults to value provided by 'commonname' arg")
 	requestCmd.PersistentFlags().StringVar(&requestOpts.assetsDir, "assetsdir", "", "Directory location for the agent where it stores signed certs")
 	requestCmd.PersistentFlags().StringVar(&requestOpts.kubeconfig, "kubeconfig", "", "Path to the kubeconfig file to connect to apiserver. If \"\", InClusterConfig is used which uses the service account kubernetes gives to pods.")
 }
@@ -75,12 +77,17 @@ func runCmdRequest(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	csrName := requestOpts.csrName
+	if csrName == "" {
+		csrName = requestOpts.commonName
+	}
 	config := agent.CSRConfig{
 		CommonName:  requestOpts.commonName,
 		OrgName:     requestOpts.orgName,
 		DNSNames:    strings.Split(requestOpts.dnsNames, ","),
 		IPAddresses: ips,
 		AssetsDir:   requestOpts.assetsDir,
+		CSRName:     csrName,
 	}
 	a, err := agent.NewAgent(config, requestOpts.kubeconfig)
 	if err != nil {

--- a/pkg/certagent/agent.go
+++ b/pkg/certagent/agent.go
@@ -34,6 +34,10 @@ type CSRConfig struct {
 	// AssetsDir is the directory location where certificates and
 	// private keys will be saved
 	AssetsDir string `json:"assetsDir"`
+
+	// CSRName is the name of the CertificateSigningRequest object
+	// that will be created
+	CSRName string `json:"csrName"`
 }
 
 // CertAgent is the top level object that represents a certificate agent.
@@ -97,7 +101,7 @@ func GenerateCSRObject(config CSRConfig) (*capi.CertificateSigningRequest, error
 
 	csr := &capi.CertificateSigningRequest{
 		TypeMeta:   metav1.TypeMeta{Kind: "CertificateSigningRequest"},
-		ObjectMeta: metav1.ObjectMeta{Name: config.CommonName},
+		ObjectMeta: metav1.ObjectMeta{Name: config.CSRName},
 		Spec: capi.CertificateSigningRequestSpec{
 			Request: csrData,
 		},
@@ -142,7 +146,7 @@ func (c *CertAgent) WaitForCertificate() (req *capi.CertificateSigningRequest, e
 
 	// implement the client GET request to the signer in a poll loop.
 	if err = wait.PollImmediate(interval, timeout, func() (bool, error) {
-		req, err = c.client.Get(c.config.CommonName, metav1.GetOptions{})
+		req, err = c.client.Get(c.config.CSRName, metav1.GetOptions{})
 		if err != nil {
 			glog.Errorf("unable to retrieve approved CSR: %v. Retrying.", err)
 			return false, nil


### PR DESCRIPTION
This change should not change any existing behaviour. If the field '--name' is
not specified then the commonname will be used for the object's name (what happens today).
When specified, the objects name will be taken accordingly. 

Useful when multiple CSR objects need to be created for the same 'commonname'.