### PR TITLE
*: add --max-retry flag to kube-client-agent

### DIFF
--- a/cmd/kube-client-agent/request.go
+++ b/cmd/kube-client-agent/request.go
@@ -26,6 +26,7 @@ var (
 		ipAddresses string
 		assetsDir   string
 		kubeconfig  string
+		maxRetry    int
 	}
 )
 
@@ -37,6 +38,7 @@ func init() {
 	requestCmd.PersistentFlags().StringVar(&requestOpts.ipAddresses, "ipaddrs", "", "Comma separated IP addresses of the node to be provided for the X509 certificate")
 	requestCmd.PersistentFlags().StringVar(&requestOpts.assetsDir, "assetsdir", "", "Directory location for the agent where it stores signed certs")
 	requestCmd.PersistentFlags().StringVar(&requestOpts.kubeconfig, "kubeconfig", "", "Path to the kubeconfig file to connect to apiserver. If \"\", InClusterConfig is used which uses the service account kubernetes gives to pods.")
+	requestCmd.PersistentFlags().IntVar(&requestOpts.maxRetry, "max-retry", 0, "If value is greater than 0 wait 10 seconds for success and retry N times.")
 }
 
 func validateRequestOpts(cmd *cobra.Command, args []string) error {
@@ -81,6 +83,7 @@ func runCmdRequest(cmd *cobra.Command, args []string) error {
 		DNSNames:    strings.Split(requestOpts.dnsNames, ","),
 		IPAddresses: ips,
 		AssetsDir:   requestOpts.assetsDir,
+		MaxRetry:    requestOpts.maxRetry,
 	}
 	a, err := agent.NewAgent(config, requestOpts.kubeconfig)
 	if err != nil {


### PR DESCRIPTION
Currently, if the server can not respond because let's say the container restarted or network partition client will exit 1. In some cases, we do not want this to be fatal and instead retry.

This PR adds a flag `--max-retry` to kube-client-agent which is disabled by default. We will sleep for 10 seconds and retry N times. If we still have a failure at that point we exit and report the error.

/cc @abhinavdahiya 

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1694169