### PR TITLE
pkg/certagent: wait forever for CSR request to reply

### DIFF
--- a/cmd/kube-client-agent/request.go
+++ b/cmd/kube-client-agent/request.go
@@ -26,7 +26,6 @@ var (
 		ipAddresses string
 		assetsDir   string
 		kubeconfig  string
-		maxRetry    int
 	}
 )
 
@@ -38,7 +37,6 @@ func init() {
 	requestCmd.PersistentFlags().StringVar(&requestOpts.ipAddresses, "ipaddrs", "", "Comma separated IP addresses of the node to be provided for the X509 certificate")
 	requestCmd.PersistentFlags().StringVar(&requestOpts.assetsDir, "assetsdir", "", "Directory location for the agent where it stores signed certs")
 	requestCmd.PersistentFlags().StringVar(&requestOpts.kubeconfig, "kubeconfig", "", "Path to the kubeconfig file to connect to apiserver. If \"\", InClusterConfig is used which uses the service account kubernetes gives to pods.")
-	requestCmd.PersistentFlags().IntVar(&requestOpts.maxRetry, "max-retry", 0, "If value is greater than 0 wait 10 seconds for success and retry N times.")
 }
 
 func validateRequestOpts(cmd *cobra.Command, args []string) error {
@@ -83,7 +81,6 @@ func runCmdRequest(cmd *cobra.Command, args []string) error {
 		DNSNames:    strings.Split(requestOpts.dnsNames, ","),
 		IPAddresses: ips,
 		AssetsDir:   requestOpts.assetsDir,
-		MaxRetry:    requestOpts.maxRetry,
 	}
 	a, err := agent.NewAgent(config, requestOpts.kubeconfig)
 	if err != nil {

--- a/pkg/certagent/agent.go
+++ b/pkg/certagent/agent.go
@@ -108,7 +108,8 @@ func GenerateCSRObject(config CSRConfig) (*capi.CertificateSigningRequest, error
 
 // RequestCertificate will create a certificate signing request for a node
 // with the config given and send it to a signer via a POST request.
-// If something goes wrong it returns an error.
+// If something goes wrong it returns an error but wait forever for
+// server to respond to request.
 // NOTE: This method does not return the approved CSR from the signer.
 func (c *CertAgent) RequestCertificate() error {
 	csr, err := GenerateCSRObject(c.config)
@@ -116,10 +117,16 @@ func (c *CertAgent) RequestCertificate() error {
 		return fmt.Errorf("error generating CSR Object: %v", err)
 	}
 
-	// send CSR to the signer
-	if _, err := c.client.Create(csr); err != nil {
-		return fmt.Errorf("error sending CSR to signer: %v", err)
-	}
+	duration := 10 * time.Second
+	// wait forever for success and retry every duration interval
+	wait.PollInfinite(duration, func() (bool, error) {
+		_, err := c.client.Create(csr)
+		if err != nil {
+			glog.Errorf("error sending CSR to signer: %v", err)
+			return false, nil
+		}
+		return true, nil
+	})
 
 	rcvdCSR, err := c.WaitForCertificate()
 	if err != nil {

--- a/pkg/certagent/agent.go
+++ b/pkg/certagent/agent.go
@@ -34,9 +34,6 @@ type CSRConfig struct {
 	// AssetsDir is the directory location where certificates and
 	// private keys will be saved
 	AssetsDir string `json:"assetsDir"`
-
-	// MaxRetry is the maximum attepts to retry client request on failure.
-	MaxRetry int `json:"maxRetry"`
 }
 
 // CertAgent is the top level object that represents a certificate agent.
@@ -111,8 +108,7 @@ func GenerateCSRObject(config CSRConfig) (*capi.CertificateSigningRequest, error
 
 // RequestCertificate will create a certificate signing request for a node
 // with the config given and send it to a signer via a POST request.
-// If something goes wrong it returns an error unless CSRConfig.MaxRetry
-// is defined in which case we will retry the request.
+// If something goes wrong it returns an error.
 // NOTE: This method does not return the approved CSR from the signer.
 func (c *CertAgent) RequestCertificate() error {
 	csr, err := GenerateCSRObject(c.config)
@@ -120,28 +116,9 @@ func (c *CertAgent) RequestCertificate() error {
 		return fmt.Errorf("error generating CSR Object: %v", err)
 	}
 
-	backoff := wait.Backoff{
-		Steps:    c.config.MaxRetry,
-		Duration: 10 * time.Second,
-		Factor:   0.0,
-	}
-
-	var lastErr error
-	// implement a retry mechanism in the case request fails.
-	errc := wait.ExponentialBackoff(backoff, func() (bool, error) {
-		// send CSR to the signer
-		_, err := c.client.Create(csr)
-		if err != nil {
-			lastErr = err
-			return false, nil
-		}
-		return true, nil
-	})
-	if errc != nil {
-		if errc == wait.ErrWaitTimeout && lastErr != nil {
-			errc = lastErr
-		}
-		return fmt.Errorf("error sending CSR to signer: %v", errc)
+	// send CSR to the signer
+	if _, err := c.client.Create(csr); err != nil {
+		return fmt.Errorf("error sending CSR to signer: %v", err)
 	}
 
 	rcvdCSR, err := c.WaitForCertificate()


### PR DESCRIPTION
This PR reverts commit 7732233fdf29a6571e8ae03da91e92a7c62a137a and add will now wait for ever for CSR request to reply. Often times for various reasons the server is not up yet so we need to wait intead of exit 1 which results in crash loop.